### PR TITLE
Dotenv needs a string, not an object

### DIFF
--- a/src/Command/AccesslevelCommand.php
+++ b/src/Command/AccesslevelCommand.php
@@ -116,7 +116,7 @@ TEXT;
         // Reload the options and read the directory config file
         $options = $optionsFactory->newInstance([], $this->getValidators());
         $configPath = new TildeExpander($dir) . '/.shootproof';
-        $configLoader = new DotenvLoader($configPath);
+        $configLoader = new DotenvLoader((string) $configPath);
         try {
             $configData = $configLoader->parse()->toArray();
             $options->loadOptionData($configData, false); // don't overwrite CLI data

--- a/src/Command/PullCommand.php
+++ b/src/Command/PullCommand.php
@@ -121,7 +121,7 @@ TEXT;
         // Reload the options and read the directory config file
         $options = $optionsFactory->newInstance([], $this->getValidators(), $this->getDefaults());
         $configPath = new TildeExpander($dir) . '/.shootproof';
-        $configLoader = new DotenvLoader($configPath);
+        $configLoader = new DotenvLoader((string) $configPath);
         try {
             $configData = $configLoader->parse()->toArray();
             $options->loadOptionData($configData, false); // don't overwrite CLI data

--- a/src/Command/PushCommand.php
+++ b/src/Command/PushCommand.php
@@ -139,7 +139,7 @@ TEXT;
         // Reload the options and read the directory config file
         $options = $optionsFactory->newInstance([], $this->getValidators(), $this->getDefaults());
         $configPath = new TildeExpander($dir) . '/.shootproof';
-        $configLoader = new DotenvLoader($configPath);
+        $configLoader = new DotenvLoader((string) $configPath);
         try {
             $configData = $configLoader->parse()->toArray();
             $options->loadOptionData($configData, false); // don't overwrite CLI data

--- a/src/OptionsFactory.php
+++ b/src/OptionsFactory.php
@@ -93,7 +93,7 @@ class OptionsFactory
         $options->loadOptionData($data->getArrayCopy()); // initial load so we can access the config option
 
         // Read config file
-        $configLoader = new DotenvLoader(new TildeExpander($options->config));
+        $configLoader = new DotenvLoader((string) new TildeExpander($options->config));
         try {
             $configData = $configLoader->parse()->toArray();
             $options->loadOptionData($configData, false); // don't overwrite CLI data


### PR DESCRIPTION
Something must have changed since v0.2.0 that broke the config loader when a `TildeExpander` object is passed.