### PR TITLE
Accept `brand` setting when creating events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /vendor/
 composer.lock
 phpunit.xml
+/examples

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing
+
+Generated source code documentation is published [here](https://shootproof.github.io/shootproof-cli/).
+
+## Run CodeSniffer
+
+``` bash
+$ ./vendor/bin/phpcs src bin bin/shootproof-cli --standard=psr2 -sp
+```
+
+Fix any errors reported before submitting a pull request.
+
+## Prepare for Release
+
+When preparing a release, clean things up with Composer before building the phar file:
+
+``` bash
+$ composer install --no-dev --prefer-source --optimize-autoloader
+```
+
+Now, you may build the phar file, and it will be cleaner and more compact.
+
+## Build the Phar File
+
+The ShootProof command line tool is distributed as an executable [phar](http://php.net/phar) file. The `build.php` script handles building this file.
+
+To build `shootproof-cli.phar`, first make sure that phar creation is enabled in your php.ini file:
+
+```
+phar.readonly = 0
+```
+
+Make sure you have enough file handles available:
+
+``` bash
+$ ulimit -Sn 4096
+```
+
+To build the phar file, change to the location of your `shootproof-cli` project clone and execute the `build.php` script:
+
+``` bash
+$ php build.php
+```
+
+This will create a `build/` directory and place the generated `shootproof-cli.phar` file there.
+
+## Generate and Publish Source Code Documentation
+
+To generate source code documentation with [ApiGen](http://www.apigen.org/) and publish to GitHub pages:
+
+``` bash
+$ git checkout master
+$ apigen generate
+$ git stash
+$ git checkout gh-pages
+$ cp -R build/apidocs/* .
+$ git add *
+$ git commit -m "Generated documentation with ApiGen"
+$ git push origin gh-pages
+$ git checkout master
+$ git stash pop
+```
+

--- a/README.md
+++ b/README.md
@@ -68,59 +68,7 @@ Non-expiring access tokens are available from ShootProof on request.
 
 ## Contributing
 
-Generated source code documentation is published [here](https://shootproof.github.io/shootproof-cli/).
-
-### Building the Phar File
-
-The ShootProof command line tool is distributed as an executable [phar](http://php.net/phar) file. The `build.php` script handles building this file.
-
-To build `shootproof-cli.phar`, first make sure that phar creation is enabled in your php.ini file:
-
-```
-phar.readonly = 0
-```
-
-Make sure you have enough file handles available:
-
-``` bash
-$ ulimit -Sn 4096
-```
-
-To build the phar file, change to the location of your `shootproof-cli` project clone and execute the `build.php` script:
-
-``` bash
-$ php build.php
-```
-
-This will create a `build/` directory and place the generated `shootproof-cli.phar` file there.
-
-### Preparing a Release
-
-When preparing a release, clean things up with Composer before building the phar file:
-
-``` bash
-$ composer install --no-dev --prefer-source --optimize-autoloader
-```
-
-Now, you may build the phar file, and it will be cleaner and more compact.
-
-### Generating and Publishing Documentation from Source Code
-
-To generate source code documentation with [ApiGen](http://www.apigen.org/) and publish to GitHub pages:
-
-``` bash
-$ git checkout master
-$ apigen generate
-$ git stash
-$ git checkout gh-pages
-$ cp -R build/apidocs/* .
-$ git add *
-$ git commit -m "Generated documentation with ApiGen"
-$ git push origin gh-pages
-$ git checkout master
-$ git stash pop
-```
-
+We welcome any bugfixes or enhancements that you would like to offer. Please see [CONTRIBUTING.md](CONTRIBUTING.md) for instructions.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ To build `shootproof-cli.phar`, first make sure that phar creation is enabled in
 phar.readonly = 0
 ```
 
+Make sure you have enough file handles available:
+
+``` bash
+$ ulimit -Sn 4096
+```
+
 To build the phar file, change to the location of your `shootproof-cli` project clone and execute the `build.php` script:
 
 ``` bash

--- a/bin/config.php
+++ b/bin/config.php
@@ -40,6 +40,7 @@ Supported commands:
 
         appId=<id>
         accessToken=<token>
+        brand=<brandId>
         verbosity=<level>
         haltOnError=true
         retryLimit=<limit>
@@ -52,6 +53,7 @@ $options = [
     'config:' => 'Path to the .shootproof configuration file',
     'app-id:' => 'ShootProof API application ID',
     'access-token:' => 'ShootProof API access token',
+    'brand:' => 'ShootProof API brand ID',
     'email:' => 'Email address to log the script results to',
     'email-from:' => 'From email address to use when emailing the script results.'
         . "\n        Ignored if --email is not set.",

--- a/bin/config.php
+++ b/bin/config.php
@@ -28,6 +28,7 @@ Supported commands:
         push
         pull
         accesslevel
+        brands
 
     For instructions on a particular command, run 'help <command>'.
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "aura/cli": "~2.0",
         "aura/di": "~2.0",
         "monolog/monolog": "~1.11",
-        "shootproof/php-sdk": "~1.1",
+        "shootproof/php-sdk": "^1.1.2",
         "symfony/finder": "~2.6"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "aura/cli": "~2.0",
         "aura/di": "~2.0",
         "monolog/monolog": "~1.11",
-        "shootproof/php-sdk": "~1.0",
+        "shootproof/php-sdk": "~1.1",
         "symfony/finder": "~2.6"
     },
     "require-dev": {

--- a/src/Command/AccesslevelCommand.php
+++ b/src/Command/AccesslevelCommand.php
@@ -82,8 +82,7 @@ TEXT;
             ],
             'password' => new CallbackValidator(function ($value, $setting, array $settings) {
                 // Require a password for certain access levels
-                switch ($settings['accessLevel'])
-                {
+                switch ($settings['accessLevel']) {
                     case 'public_password':
                     case 'private_password':
                         // Was the --password option passed with no value?

--- a/src/Command/AccesslevelCommand.php
+++ b/src/Command/AccesslevelCommand.php
@@ -116,7 +116,7 @@ TEXT;
         // Reload the options and read the directory config file
         $options = $optionsFactory->newInstance([], $this->getValidators());
         $configPath = new TildeExpander($dir) . '/.shootproof';
-        $configLoader = new DotenvLoader($configPath);
+        $configLoader = new DotenvLoader((string) $configPath);
         try {
             $configData = $configLoader->parse()->toArray();
             $options->loadOptionData($configData, false); // don't overwrite CLI data

--- a/src/Command/BrandsCommand.php
+++ b/src/Command/BrandsCommand.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * This file is part of the ShootProof command line tool.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright Copyright (c) ShootProof, LLC (https://www.shootproof.com)
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+
+namespace ShootProof\Cli\Command;
+
+use Aura\Cli\Context;
+use ShootProof\Cli\Options;
+use ShootProof\Cli\OptionsFactory;
+use Sp_Api as ShootProofApi;
+
+/**
+ * Provides the shootproof-cli list-brands command
+ */
+class BrandsCommand extends BaseCommand implements HelpableCommandInterface
+{
+    use HelpableCommandTrait;
+
+    /**
+     * @var string
+     */
+    public static $usage = 'brands [options]';
+
+    /**
+     * @var string
+     */
+    public static $description = <<<TEXT
+Lists the brands for a ShootProof account.
+TEXT;
+
+    /**
+     * @var array
+     */
+    public static $options = [];
+
+    /**
+     * Called when this object is called as a function
+     *
+     * @param Context $context
+     * @param OptionsFactory $optionsFactory
+     * @throws \Exception if haltOnError setting is true
+     */
+    public function __invoke(Context $context, OptionsFactory $optionsFactory)
+    {
+        $getopt = $context->getopt(array_keys(self::$options));
+
+        // Load base options
+        $baseOptions = $optionsFactory->newInstance();
+        $baseOptions->validateAllRequired();
+
+        $result = $this->api->getBrands();
+        $this->stdio->outln(json_encode($result['brands'], JSON_PRETTY_PRINT));
+    }
+
+    protected function processDirectory($dir, Options $baseOptions, OptionsFactory $optionsFactory)
+    {
+    }
+}

--- a/src/Command/HelpCommand.php
+++ b/src/Command/HelpCommand.php
@@ -36,6 +36,7 @@ Displays this help screen, or help for a specific command.
         push
         pull
         accesslevel
+        brands
 TEXT;
 
     /**

--- a/src/Command/PullCommand.php
+++ b/src/Command/PullCommand.php
@@ -121,7 +121,7 @@ TEXT;
         // Reload the options and read the directory config file
         $options = $optionsFactory->newInstance([], $this->getValidators(), $this->getDefaults());
         $configPath = new TildeExpander($dir) . '/.shootproof';
-        $configLoader = new DotenvLoader($configPath);
+        $configLoader = new DotenvLoader((string) $configPath);
         try {
             $configData = $configLoader->parse()->toArray();
             $options->loadOptionData($configData, false); // don't overwrite CLI data

--- a/src/Command/PullCommand.php
+++ b/src/Command/PullCommand.php
@@ -141,8 +141,7 @@ TEXT;
         $localFiles = array_map('basename', $this->getFileList($dir));
 
         // Get remote file list
-        switch ($options->target)
-        {
+        switch ($options->target) {
             case 'album':
                 $this->logger->addDebug('Fetching album photos', [$options->album]);
                 $remoteFiles = new ResultPager(function ($page) use ($options) {
@@ -210,8 +209,7 @@ TEXT;
             $this->logger->addDebug('ShootProof settings file saved', [$configPath]);
         } catch (\InvalidArgumentException $e) {
             $this->logger->addWarning('ShootProof settings file is unwritable', [$configPath]);
-        }
-        catch (\RuntimeException $e) {
+        } catch (\RuntimeException $e) {
             $this->logger->addWarning('Failed writing ShootProof settings file', [$configPath]);
         }
     }

--- a/src/Command/PushCommand.php
+++ b/src/Command/PushCommand.php
@@ -139,7 +139,7 @@ TEXT;
         // Reload the options and read the directory config file
         $options = $optionsFactory->newInstance([], $this->getValidators(), $this->getDefaults());
         $configPath = new TildeExpander($dir) . '/.shootproof';
-        $configLoader = new DotenvLoader($configPath);
+        $configLoader = new DotenvLoader((string) $configPath);
         try {
             $configData = $configLoader->parse()->toArray();
             $options->loadOptionData($configData, false); // don't overwrite CLI data

--- a/src/Command/PushCommand.php
+++ b/src/Command/PushCommand.php
@@ -76,6 +76,7 @@ Uploads photos in a directory or set of directories to a ShootProof
         parentAlbum=<parentAlbumId>
         albumName=<name>
         albumPassword=<password>
+        brand=<brandId>
 
     After this command completes successfully, a .shootproof file will be
     written to the directory for use in subsequent runs.
@@ -346,9 +347,13 @@ TEXT;
     protected function createEvent(Options $options, $defaultName)
     {
         $eventName = $options->eventName ? $options->eventName : $defaultName;
+        $brandId = $options->brand ? $options->brand : null;
         $this->logger->addNotice('Creating ShootProof event', [$eventName]);
+        if ($brandId) {
+            $this->logger->addNotice('Using brand ID', [$brandId]);
+        }
         if (! $options->preview) {
-            $response = $this->api->createEvent($eventName);
+            $response = $this->api->createEvent($eventName, $brandId);
             return $response['event']['id'];
         } else {
             return 'EVENT_ID_PREVIEW';

--- a/src/Command/PushCommand.php
+++ b/src/Command/PushCommand.php
@@ -160,10 +160,8 @@ TEXT;
         $albumId = $options->album ? $options->album : null;
 
         // Get remote file list
-        switch ($options->target)
-        {
+        switch ($options->target) {
             case 'album':
-
                 // Create the album
                 if (! $albumId) {
                     list($eventId, $albumId) = $this->createAlbum($options, basename($dir));
@@ -184,7 +182,6 @@ TEXT;
                 break;
 
             case 'event':
-
                 // Create the event
                 if (! $eventId) {
                     $eventId = $this->createEvent($options, basename($dir));
@@ -247,8 +244,7 @@ TEXT;
             $this->logger->addDebug('ShootProof settings file saved', [$configPath]);
         } catch (\InvalidArgumentException $e) {
             $this->logger->addWarning('ShootProof settings file is unwritable', [$configPath]);
-        }
-        catch (\RuntimeException $e) {
+        } catch (\RuntimeException $e) {
             $this->logger->addWarning('Failed writing ShootProof settings file', [$configPath]);
         }
     }

--- a/src/DependencyConfig.php
+++ b/src/DependencyConfig.php
@@ -39,6 +39,7 @@ class DependencyConfig extends Config
         $di->set('push', $di->lazyNew('ShootProof\Cli\Command\PushCommand'));
         $di->set('pull', $di->lazyNew('ShootProof\Cli\Command\PullCommand'));
         $di->set('accesslevel', $di->lazyNew('ShootProof\Cli\Command\AccesslevelCommand'));
+        $di->set('brands', $di->lazyNew('ShootProof\Cli\Command\BrandsCommand'));
         $di->set('help', $di->lazyNew('ShootProof\Cli\Command\HelpCommand'));
     }
 }

--- a/src/OptionsFactory.php
+++ b/src/OptionsFactory.php
@@ -93,7 +93,7 @@ class OptionsFactory
         $options->loadOptionData($data->getArrayCopy()); // initial load so we can access the config option
 
         // Read config file
-        $configLoader = new DotenvLoader(new TildeExpander($options->config));
+        $configLoader = new DotenvLoader((string) new TildeExpander($options->config));
         try {
             $configData = $configLoader->parse()->toArray();
             $options->loadOptionData($configData, false); // don't overwrite CLI data

--- a/src/Validators/ShootProofBrandValidator.php
+++ b/src/Validators/ShootProofBrandValidator.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * This file is part of the ShootProof command line tool.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright Copyright (c) ShootProof, LLC (https://www.shootproof.com)
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+
+namespace ShootProof\Cli\Validators;
+
+/**
+ * Validates that the value is a valid ShootProof brand
+ *
+ * @todo Complete validation functionality for ShootProofBrandValidator
+ */
+class ShootProofBrandValidator extends ShootproofEntityValidator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function __invoke($value, $setting = null, array $settings = [])
+    {
+        try {
+            // call $api with $entity $value
+            return true;
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Add `brand` to the `.shootproof` config file, or specify on the command line with `--brand=<id>`.